### PR TITLE
fix articles SEO canonical

### DIFF
--- a/src/lib/components/Nav/DesktopNav.svelte
+++ b/src/lib/components/Nav/DesktopNav.svelte
@@ -21,7 +21,8 @@
 
   const style = $derived(twMerge('flex h-full items-center justify-between', additionalClass));
   const multiLocale = $derived(
-    page.data.seo.alternate && page.data.seo.alternate.length > 1 || page.data.seo.articleAlternate && page.data.seo.articleAlternate.length > 1
+    (page.data.seo.alternate && page.data.seo.alternate.length > 1) ||
+      (page.data.seo.articleAlternate && page.data.seo.articleAlternate.length > 1)
   );
 </script>
 

--- a/src/lib/components/Nav/DesktopNav.svelte
+++ b/src/lib/components/Nav/DesktopNav.svelte
@@ -20,6 +20,9 @@
   const { class: additionalClass, locale }: Props = $props();
 
   const style = $derived(twMerge('flex h-full items-center justify-between', additionalClass));
+  const multiLocale = $derived(
+    page.data.seo.alternate && page.data.seo.alternate.length > 1 || page.data.seo.articleAlternate && page.data.seo.articleAlternate.length > 1
+  );
 </script>
 
 <nav class={style} aria-labelledby="desktop-navigation">
@@ -96,18 +99,19 @@
       <div tabindex="0" role="button" class="mx-8 my-3 rounded-none">
         <p class="text-brand-600 flex items-center py-1.5 text-[17px] font-bold xl:py-9">
           <span>{locale.toUpperCase()}</span>
-          {#if page.data.seo.alternate.length > 1}
+          {#if multiLocale}
             <ChevronDown strokeWidth={3} class="text-base-content invertable ml-2 h-4 w-4" />
           {/if}
         </p>
       </div>
-      {#if page.data.seo.alternate.length > 1}
+      {#if multiLocale}
+        {@const alternates = page.data.seo.alternate ?? page.data.seo.articleAlternate}
         <div>
           <ul
             class="items-list dropdown-content bg-base-200 dark:bg-base-300 border-t-brand-600 left-5 z-1 w-16 border-t p-2 shadow-xs"
           >
             {#key page.url}
-              {#each page.data.seo.alternate as alternate (alternate.hreflang)}
+              {#each alternates as alternate (alternate.hreflang)}
                 <li>
                   <Link
                     class={`items-list-element text-brand-600 hover:bg-base-100 flex items-center justify-center py-3 text-center font-bold opacity-100 transition-all hover:rounded-sm hover:opacity-75 dark:hover:bg-slate-600 ${alternate.hreflang === locale ? 'hidden' : ''}`}

--- a/src/lib/components/Nav/MobileNav.svelte
+++ b/src/lib/components/Nav/MobileNav.svelte
@@ -12,7 +12,6 @@
   import Shelf from '../Shelf.svelte';
   import SocialNetworks from '../SocialNetworks.svelte';
   import Logo from './Logo.svelte';
-  import type { SeoHeader } from '$types';
   import { resolve } from '$app/paths';
   import type { Pathname } from '$app/types';
 
@@ -23,7 +22,9 @@
   };
 
   const { class: additionalClass, maxWidth = maxMobileWidth, locale }: Props = $props();
-  const pageSeo: SeoHeader = $derived(page.data.seo);
+  const multiLocale = $derived(
+    page.data.seo.alternate && page.data.seo.alternate.length > 1 || page.data.seo.articleAlternate && page.data.seo.articleAlternate.length > 1
+  );
   const style: string = $derived(
     twMerge('flex h-full items-center justify-between', additionalClass)
   );
@@ -77,18 +78,19 @@
       <div tabindex="0" role="button" class="mx-8 my-3 rounded-none">
         <p class="text-brand-600 flex items-center py-1.5 text-[17px] font-bold xl:py-9">
           <span>{locale.toUpperCase()}</span>
-          {#if pageSeo.alternate.length > 1}
+          {#if multiLocale}
             <ChevronDown strokeWidth={3} class="text-base-content invertable ml-2 h-4 w-4" />
           {/if}
         </p>
       </div>
-      {#if pageSeo.alternate.length > 1}
-        <div>
+      {#if multiLocale}
+        {@const alternates = page.data.seo.alternate ?? page.data.seo.articleAlternate}
+      <div>
           <ul
             class="items-list dropdown-content bg-base-200 dark:bg-base-300 border-t-brand-600 left-5 z-1 w-16 border-t p-2 shadow-xs"
           >
-            {#key pageSeo.alternate}
-              {#each pageSeo.alternate as alternate (alternate.hreflang)}
+            {#key page.url}
+              {#each alternates as alternate (alternate.hreflang)}
                 <li>
                   <Link
                     class={`items-list-element text-brand-600 hover:bg-base-100 flex items-center justify-center py-3 text-center font-bold opacity-100 transition-all hover:rounded-sm hover:opacity-75 ${alternate.hreflang === locale ? 'hidden' : ''}`}
@@ -128,18 +130,19 @@
           <div tabindex="0" role="button" class="mx-8 my-3 rounded-none">
             <p class="text-brand-600 flex items-center py-1.5 text-[17px] font-bold xl:py-9">
               <span>{locale.toUpperCase()}</span>
-              {#if pageSeo.alternate.length > 1}
+              {#if multiLocale}
                 <ChevronDown strokeWidth={3} class="text-base-content invertable ml-2 h-4 w-4" />
               {/if}
             </p>
           </div>
-          {#if pageSeo.alternate.length > 1}
+          {#if multiLocale}
+            {@const alternates = page.data.seo.alternate ?? page.data.seo.articleAlternate}
             <div>
               <ul
                 class="items-list dropdown-content bg-base-200 dark:bg-base-300 border-t-brand-600 left-5 z-1 w-16 border-t p-2 shadow-xs"
               >
-                {#key pageSeo.alternate}
-                  {#each pageSeo.alternate as alternate (alternate.hreflang)}
+                {#key page.url}
+                  {#each alternates as alternate (alternate.hreflang)}
                     <li>
                       <Link
                         class={`items-list-element text-brand-600 hover:bg-base-100 flex items-center justify-center py-3 text-center font-bold opacity-100 transition-all hover:rounded-sm hover:opacity-75 ${alternate.hreflang === locale ? 'hidden' : ''}`}

--- a/src/lib/components/Nav/MobileNav.svelte
+++ b/src/lib/components/Nav/MobileNav.svelte
@@ -23,7 +23,8 @@
 
   const { class: additionalClass, maxWidth = maxMobileWidth, locale }: Props = $props();
   const multiLocale = $derived(
-    page.data.seo.alternate && page.data.seo.alternate.length > 1 || page.data.seo.articleAlternate && page.data.seo.articleAlternate.length > 1
+    (page.data.seo.alternate && page.data.seo.alternate.length > 1) ||
+      (page.data.seo.articleAlternate && page.data.seo.articleAlternate.length > 1)
   );
   const style: string = $derived(
     twMerge('flex h-full items-center justify-between', additionalClass)
@@ -85,7 +86,7 @@
       </div>
       {#if multiLocale}
         {@const alternates = page.data.seo.alternate ?? page.data.seo.articleAlternate}
-      <div>
+        <div>
           <ul
             class="items-list dropdown-content bg-base-200 dark:bg-base-300 border-t-brand-600 left-5 z-1 w-16 border-t p-2 shadow-xs"
           >

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -32,7 +32,8 @@ export type SeoHeader = {
   title: string;
   description: string;
   image: string;
-  alternate: SeoAlternate[];
+  alternate?: SeoAlternate[];
+  articleAlternate?: SeoAlternate[];
 };
 
 export type SeoAlternate = {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,11 +26,11 @@
       description: pageData.seo.description,
       canonical: pageData.seo.canonical,
       alternates: pageData.seo.alternate
-        .map(
+        ?.map(
           (alternate) =>
             `<link rel="alternate" hreflang="${alternate.hreflang}" href="${page.url.origin}${alternate.href}" />`
         )
-        .join('\n'),
+        ?.join('\n'),
       image: pageData.seo.image
     };
   });

--- a/src/routes/[locale=locale]/(type)/[type=typeArticles]/[...slug]/+layout.server.ts
+++ b/src/routes/[locale=locale]/(type)/[type=typeArticles]/[...slug]/+layout.server.ts
@@ -24,7 +24,7 @@ export const load = async ({ params, parent, url }) => {
   await loadTranslations(locale, url.pathname);
 
   const seo: SeoHeader = {
-    canonical: `${url.origin}${url.pathname}`,
+    canonical: `https://www.lausanne-tourisme.ch/${locale}/the-lausanner/articles/${article.seo?.slug?.[locale]}`,
     title: article.name?.[locale as Locale] ?? translations[locale][`${RouteTypes.Articles}.title`],
     description:
       article.lead?.[locale as Locale] ??
@@ -34,7 +34,7 @@ export const load = async ({ params, parent, url }) => {
       usePreset: false,
       transform: { h: 720, w: 1280 }
     }),
-    alternate: supportedLocales
+    articleAlternate: supportedLocales
       .filter((l) => article.languages?.includes(l))
       .map((locale) => ({
         hreflang: locale,


### PR DESCRIPTION
update SeoHeader object to remove alternates in <head> when it's articles, because they are a copy from lausanne-tourisme.ch.

Refactor locale switcher to use "articleAlternate" when "alternate" is empty.